### PR TITLE
Update README and gitignore, fix linkerd helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.envrc

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Bootsrap Flux and your repository into your cluster.
 If you do not have one, you can create one with `kind create cluster`
 
 ```console
-flux boostrap github \
+flux bootstrap github \
   --personal \
   --owner "${GITHUB_USER}" \
   --repository "${GITHUB_REPO}" \

--- a/infrastructure/linkerd/README.md
+++ b/infrastructure/linkerd/README.md
@@ -1,6 +1,6 @@
 # Generate Linkerd v2 certificates
 
-Install the step CLI on MacOS and Linux using Homebrew run:
+Install the [step CLI](https://smallstep.com/docs/step-ca/installation) on MacOS and Linux using Homebrew run:
 
 ```sh
 brew install step

--- a/infrastructure/linkerd/linkerd-release.yaml
+++ b/infrastructure/linkerd/linkerd-release.yaml
@@ -16,7 +16,7 @@ spec:
     - kind: Secret
       name: linkerd-certs
       valuesKey: ca.crt
-      targetPath: global.identityTrustAnchorsPEM
+      targetPath: identityTrustAnchorsPEM
     - kind: Secret
       name: linkerd-certs
       valuesKey: issuer.crt


### PR DESCRIPTION
* Linkerd helm chart have updates it's values so global var dosen't exist any more.
* There are multiple things called step in the arch world so added a link so It's easy to understand what step actually is.
* .gitignore .envrc
* Minor spel issue of bootstrap in readme